### PR TITLE
exifutils: dedup {cam,lens}_make and {cam,lens}_model

### DIFF
--- a/src/exifutils/exiftoolworker.py
+++ b/src/exifutils/exiftoolworker.py
@@ -72,6 +72,9 @@ class ExifToolWorker(ExifWorker):
         else:
             logging.warning("Unknown camera make, return as is")
             if cam_make or cam_model:
+                if cam_make and cam_model:
+                    if cam_model.lower().startswith(cam_make):
+                        return cam_model
                 cam_make = cam_make if cam_make else "Unknown Make"
                 cam_model = cam_model if cam_model else "Unknown Model"
                 return f"{cam_make} {cam_model}"

--- a/src/exifutils/pillowworker.py
+++ b/src/exifutils/pillowworker.py
@@ -89,6 +89,9 @@ class PillowWorker(ExifWorker):
         else:
             logging.warning("Unknown camera make, return as is")
             if cam_make or cam_model:
+                if cam_make and cam_model:
+                    if cam_model.lower().startswith(cam_make):
+                        return cam_model
                 cam_make = cam_make if cam_make else "Unknown Make"
                 cam_model = cam_model if cam_model else "Unknown Model"
                 return f"{cam_make} {cam_model}"

--- a/src/exifutils/pillowworker.py
+++ b/src/exifutils/pillowworker.py
@@ -129,6 +129,9 @@ class PillowWorker(ExifWorker):
         else:
             logging.warning("Unknown lens make, return as is")
             if lens_make or lens_model:
+                if lens_make and lens_model:
+                    if lens_model.lower().startswith(lens_make):
+                        return lens_model
                 lens_make = lens_make if lens_make else "Unknown Make"
                 lens_model = lens_model if lens_model else "Unknown Model"
                 return f"{lens_make} {lens_model}"


### PR DESCRIPTION
De-duplicate cam_make and cam_model, as well as lens_make and lens_model, to avoid displaying the Make name repeatedly. 