### PR TITLE
35mm equivalent Depth of Field information

### DIFF
--- a/fotobot/exif/exiftoolworker.py
+++ b/fotobot/exif/exiftoolworker.py
@@ -136,6 +136,10 @@ class ExifToolWorker(ExifWorker):
         aperture = self.get_tag_with_log("Aperture")
         return f"f/{aperture}" if aperture else "Unknown Aperture"
     
+    def get_dof_in_35mm(self) -> str:
+        '''Not implemented yet, see PillowWorker'''
+        return "Unknown Depth of Field in 35mm format"
+
     def get_shutter_speed(self) -> str:
         shutter_speed = self.get_tag_with_log("ShutterSpeed")
         return f"{shutter_speed}s" if shutter_speed else "Unknown Shutter Speed"

--- a/fotobot/exif/exiftoolworker.py
+++ b/fotobot/exif/exiftoolworker.py
@@ -137,17 +137,25 @@ class ExifToolWorker(ExifWorker):
         return f"f/{aperture}" if aperture else "Unknown Aperture"
     
     def get_dof_in_35mm(self) -> str:
-        focal_length = self.get_tag_with_log("FocalLength")
-        focal_length_35mm = self.get_tag_with_log("FocalLengthIn35mmFormat")
-        aperture = self.get_tag_with_log("Aperture"))
+        f_focal_length = None
+        f_focal_length_35mm = None
+        f_aperture = None
+
+        if (focal_length := self.get_tag_with_log("FocalLength")) is not None:
+            f_focal_length = float(focal_length)
+        if (focal_length_35mm := self.get_tag_with_log("FocalLengthIn35mmFormat")) is not None:
+            f_focal_length_35mm = float(focal_length_35mm)
+        elif (focal_length_35mm := self.get_tag_with_log("FocalLength35efl")) is not None:
+            f_focal_length_35mm = float(focal_length_35mm)
+        if (aperture := self.get_tag_with_log("Aperture")) is not None:
+            f_aperture = float(aperture)
 
         dof_in_35mm = None
 
-        if aperture and focal_length and focal_length_35mm:
-            dof_in_35mm = round(
-                    float(focal_length_35mm) / float(focal_length) * float(aperture), 1)
+        if f_aperture and f_focal_length and f_focal_length_35mm:
+            dof_in_35mm = round(f_focal_length_35mm / f_focal_length * f_aperture, 1)
 
-        return f"f/{dof_in_35mm}" if dof_in_35mm else "Unknown Depth of Field in 35mm format
+        return f"f/{dof_in_35mm}" if dof_in_35mm else "Unknown Depth of Field in 35mm format"
 
     def get_shutter_speed(self) -> str:
         shutter_speed = self.get_tag_with_log("ShutterSpeed")

--- a/fotobot/exif/exiftoolworker.py
+++ b/fotobot/exif/exiftoolworker.py
@@ -137,8 +137,17 @@ class ExifToolWorker(ExifWorker):
         return f"f/{aperture}" if aperture else "Unknown Aperture"
     
     def get_dof_in_35mm(self) -> str:
-        '''Not implemented yet, see PillowWorker'''
-        return "Unknown Depth of Field in 35mm format"
+        focal_length = self.get_tag_with_log("FocalLength")
+        focal_length_35mm = self.get_tag_with_log("FocalLengthIn35mmFormat")
+        aperture = self.get_tag_with_log("Aperture"))
+
+        dof_in_35mm = None
+
+        if aperture and focal_length and focal_length_35mm:
+            dof_in_35mm = round(
+                    float(focal_length_35mm) / float(focal_length) * float(aperture), 1)
+
+        return f"f/{dof_in_35mm}" if dof_in_35mm else "Unknown Depth of Field in 35mm format
 
     def get_shutter_speed(self) -> str:
         shutter_speed = self.get_tag_with_log("ShutterSpeed")

--- a/fotobot/exif/exifworker.py
+++ b/fotobot/exif/exifworker.py
@@ -28,6 +28,10 @@ class ExifWorker(ABC):
         pass
 
     @abstractmethod
+    def get_dof_in_35mm(self) -> str:
+        pass
+
+    @abstractmethod
     def get_shutter_speed(self) -> str:
         pass
 
@@ -95,6 +99,7 @@ class ExifWorker(ABC):
             'focal_length': self.get_focal_length(),
             'focal_length_in_35mm': self.get_focal_length_in_35mm(), # 'focal_length_35mm' is added to the mapping
             'aperture': self.get_aperture(),
+            'dof_in_35mm': self.get_dof_in_35mm(),
             'shutter_speed': self.get_shutter_speed(),
             'iso': self.get_iso(),
             'exposure_compensation': self.get_exposure_compensation(),

--- a/fotobot/exif/pillowworker.py
+++ b/fotobot/exif/pillowworker.py
@@ -138,6 +138,8 @@ class PillowWorker(ExifWorker):
         focal_length_35mm = self.get_tag_with_log(ExifTags.Base.FocalLengthIn35mmFilm)
         aperture = self.get_tag_with_log(ExifTags.Base.FNumber)
 
+        dof_in_35mm = None
+
         if aperture and focal_length and focal_length_35mm:
             dof_in_35mm = round(float(focal_length_35mm / focal_length * aperture), 1)
 

--- a/fotobot/exif/pillowworker.py
+++ b/fotobot/exif/pillowworker.py
@@ -133,6 +133,16 @@ class PillowWorker(ExifWorker):
         aperture = self.get_tag_with_log(ExifTags.Base.FNumber)
         return f"f/{aperture}" if aperture else "Unknown Aperture"
 
+    def get_dof_in_35mm(self) -> str:
+        focal_length = self.get_tag_with_log(ExifTags.Base.FocalLength)
+        focal_length_35mm = self.get_tag_with_log(ExifTags.Base.FocalLengthIn35mmFilm)
+        aperture = self.get_tag_with_log(ExifTags.Base.FNumber)
+
+        if aperture and focal_length and focal_length_35mm:
+            dof_in_35mm = round(float(focal_length_35mm / focal_length * aperture), 1)
+
+        return f"f/{dof_in_35mm}" if dof_in_35mm else "Unknown Depth of Field in 35mm format"
+
     def get_shutter_speed(self) -> str:
         shutter_speed = self.get_tag_with_log(ExifTags.Base.ExposureTime)
         return f"{self.float2frac(float(shutter_speed))}s" if shutter_speed != "" else "Unknown Shutter Speed"

--- a/fotobot/exif/styles.py
+++ b/fotobot/exif/styles.py
@@ -27,7 +27,7 @@ def get_default_style(full_frame=False, special=False, unknown=False,
         if special:
             style += "$focal_length_in_35mm, $aperture, $shutter_speed, $iso\n"
         else:
-            style += "$focal_length ($focal_length_in_35mm equiv), $aperture, $shutter_speed, $iso\n"
+            style += "$focal_length ($focal_length_in_35mm equiv), $aperture ($dof_in_35mm equiv), $shutter_speed, $iso\n"
 
     if location or country:
         if country and country:
@@ -51,6 +51,7 @@ def get_full_style(full_frame=False, exposure_compensation=False, metering=False
 
     if not full_frame:
         style += "[Focal Length in 35mm]\n" + "    $focal_length_in_35mm\n"
+        style += "[Depth of Field in 35mm]\n" + "    $dof_in_35mm\n"
 
     style += "[Aperture]\n" + "    $aperture\n"
     style += "[Shutter Speed]\n" + "    $shutter_speed\n"


### PR DESCRIPTION
Adds the calculation of DoF in 35mm format (only PillowWorker atm), to reduce confusions for small format cameras with lens having large F-Number (e.g. mobile phones).